### PR TITLE
Remove unnecessary sampler start_pixel parameters

### DIFF
--- a/src/core/pixel_sampler.cpp
+++ b/src/core/pixel_sampler.cpp
@@ -26,9 +26,9 @@ namespace lux {
     }
   }
 
-  void Pixel_sampler::start_pixel(const int x, const int y) {
+  void Pixel_sampler::start_pixel() {
     m_current_1D_dimension = m_current_2D_dimension = 0;
-    Sampler::start_pixel(x, y);
+    Sampler::start_pixel();
   }
 
   bool Pixel_sampler::start_next_sample() {

--- a/src/core/pixel_sampler.h
+++ b/src/core/pixel_sampler.h
@@ -13,7 +13,7 @@ namespace lux {
   class Pixel_sampler : public Sampler {
     public:
       Pixel_sampler(const std::uint64_t samples_per_pixel, const unsigned dimensions_per_sample);
-      virtual void start_pixel(const int x, const int y) override;
+      virtual void start_pixel() override;
       virtual bool start_next_sample() override;
 
       virtual float get_1D() override;

--- a/src/core/sampler.cpp
+++ b/src/core/sampler.cpp
@@ -6,7 +6,7 @@ namespace lux {
   Sampler::Sampler(const std::uint64_t samples_per_pixel)
       : m_samples_per_pixel(samples_per_pixel), m_current_pixel_sample_index(0) {} 
 
-  void Sampler::start_pixel(const int x, const int y) {
+  void Sampler::start_pixel() {
     m_current_pixel_sample_index = 0;
   }
 

--- a/src/core/sampler.h
+++ b/src/core/sampler.h
@@ -12,7 +12,7 @@ namespace lux {
 
       virtual ~Sampler() {}
 
-      virtual void start_pixel(const int x, const int y);
+      virtual void start_pixel();
       virtual bool start_next_sample();
 
       virtual float get_1D() = 0;

--- a/src/integrators/path_tracer.cpp
+++ b/src/integrators/path_tracer.cpp
@@ -10,7 +10,7 @@ namespace lux {
   Path_tracer::Path_tracer(Sampler * psampler, unsigned max_depth)
     : m_psampler(psampler), m_kmax_depth(max_depth)
   {
-    psampler -> start_pixel(0, 0);
+    psampler -> start_pixel();
   }
 
   RGB_spectrum Path_tracer::li(const Scene & scene, const Ray & r)
@@ -56,7 +56,7 @@ namespace lux {
       }
     }
 
-    if(!m_psampler->start_next_sample()) m_psampler->start_pixel(0, 0);
+    if(!m_psampler->start_next_sample()) m_psampler->start_pixel();
 
     return L;
   }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -176,7 +176,7 @@ int main(int argc, char * argv[])
   lux::Camera_sample camera_sample;
   for (unsigned h = 0; h != resolution.y; ++h) {
     for (unsigned w = 0; w != resolution.x; ++w) {
-      stratified_sampler.start_pixel(w, h);
+      stratified_sampler.start_pixel();
       lux::RGB_spectrum pixel_color;
       lux::RGB_spectrum sample_color;
 

--- a/src/samplers/stratified.cpp
+++ b/src/samplers/stratified.cpp
@@ -14,7 +14,7 @@ namespace lux {
         m_y_pixel_samples(y_pixel_samples),
         m_jittered_samples(jittered_samples) {}
 
-  void Stratified_sampler::start_pixel(const int x, const int y)
+  void Stratified_sampler::start_pixel()
   {
     for (unsigned i = 0; i != m_samples_1D.size(); ++i) {
       stratify_1D_samples(&m_samples_1D[i][0]);
@@ -26,7 +26,7 @@ namespace lux {
       shuffle(&m_samples_2D[i][0], m_x_pixel_samples * m_y_pixel_samples, m_rng);
     }
 
-    Pixel_sampler::start_pixel(x, y);
+    Pixel_sampler::start_pixel();
   }
 
   void Stratified_sampler::stratify_1D_samples(float * samples_1D)

--- a/src/samplers/stratified.h
+++ b/src/samplers/stratified.h
@@ -11,7 +11,7 @@ namespace lux {
       Stratified_sampler(const unsigned x_pixel_samples, const unsigned y_pixel_samples,
                          const unsigned dimensions_per_sample, const bool jittered_samples);
 
-      virtual void start_pixel(const int x, const int y) override;
+      virtual void start_pixel() override;
 
     private:
       void stratify_1D_samples(float * samples_1D);


### PR DESCRIPTION
### Description
  Removes the start_pixel parameters, since they are not necessary for the samplers we have and for the ones we intent on creating further on.